### PR TITLE
Fix typo kye -> key

### DIFF
--- a/projects/ngx-oneforall-docs/src/app/categories/utils/pages/is-key-defined/ng-doc.page.ts
+++ b/projects/ngx-oneforall-docs/src/app/categories/utils/pages/is-key-defined/ng-doc.page.ts
@@ -2,7 +2,7 @@ import { NgDocPage } from '@ng-doc/core';
 import UtilsCategory from '../../ng-doc.category';
 
 const isKeyDefined: NgDocPage = {
-  title: 'Is Kye Defined',
+  title: 'Is Key Defined',
   mdFile: './index.md',
   category: UtilsCategory,
 };


### PR DESCRIPTION
As title say, there was a typo.

No docs build, I assume it's done by a continuous delivery.