### PR TITLE
docs: add installation instructions for various pipes

### DIFF
--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/bytes/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/bytes/index.md
@@ -2,6 +2,12 @@
 
 The `BytesPipe` converts a number (in bytes) into a human-readable string with appropriate units (B, KB, MB, GB, TB, PB). It automatically selects the best unit and formats the number with configurable decimal places.
 
+### Installation
+
+```ts
+import { BytesPipe } from 'ngx-oneforall/pipes/bytes';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L4

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/call/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/call/index.md
@@ -2,6 +2,12 @@
 
 The `CallPipe` invokes a function directly from the template with pure pipe caching. This prevents unnecessary change detection cycles since the function is only re-evaluated when its reference or arguments change.
 
+### Installation
+
+```ts
+import { CallPipe } from 'ngx-oneforall/pipes/call';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L2

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/first-error-key/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/first-error-key/index.md
@@ -2,6 +2,12 @@
 
 The `FirstErrorKeyPipe` extracts the first validation error key from a form control's errors. It supports optional priority ordering to control which error displays first.
 
+### Installation
+
+```ts
+import { FirstErrorKeyPipe } from 'ngx-oneforall/pipes/first-error-key';
+```
+
 ### Usage
 
 ```html file="./demo/snippets.html"#L4-L6

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/highlight-search/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/highlight-search/index.md
@@ -2,6 +2,12 @@
 
 The `HighlightSearchPipe` highlights search matches by wrapping them in customizable HTML tags. Supports optional CSS classes for styling.
 
+### Installation
+
+```ts
+import { HighlightSearchPipe } from 'ngx-oneforall/pipes/highlight-search';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L2

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/initials/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/initials/index.md
@@ -2,12 +2,15 @@
 
 The `initials` pipe transforms a name or string into its initials. It handles single or multiple words and allows customizing the number of initials returned.
 
+### Installation
+
+```ts
+import { InitialsPipe } from 'ngx-oneforall/pipes/initials';
+```
+
 ### Usage
 
-Import the `InitialsPipe` from `ngx-oneforall/pipes/initials`.
-
-```typescript
-import { InitialsPipe } from 'ngx-oneforall/pipes/initials';
+```html file="./snippets.html"#L2-L3
 ```
 
 ### Examples

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/pluralize/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/pluralize/index.md
@@ -2,6 +2,12 @@
 
 The `PluralizePipe` handles word pluralization with automatic English rules and custom plural support.
 
+### Installation
+
+```ts
+import { PluralizePipe } from 'ngx-oneforall/pipes/pluralize';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L5

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/range/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/range/index.md
@@ -2,6 +2,12 @@
 
 The `RangePipe` generates an array of numbers in a range. Follows Python's `range()` convention.
 
+### Installation
+
+```ts
+import { RangePipe } from 'ngx-oneforall/pipes/range';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L5

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/safe-html/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/safe-html/index.md
@@ -4,6 +4,12 @@ The `SafeHtmlPipe` bypasses Angular's HTML sanitization to render trusted HTML c
 
 > **⚠️ Security Warning** Only use with trusted content. User input must be sanitized server-side.
 
+### Installation
+
+```ts
+import { SafeHtmlPipe } from 'ngx-oneforall/pipes/safe-html';
+```
+
 ### Usage
 
 ```html

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/time-ago/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/time-ago/index.md
@@ -2,6 +2,12 @@
 
 The `TimeAgoPipe` displays relative time (e.g., "2 hours ago", "in 3 days"). Supports live updates, future dates, and customizable labels.
 
+### Installation
+
+```ts
+import { TimeAgoPipe } from 'ngx-oneforall/pipes/time-ago';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L2

--- a/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/truncate/index.md
+++ b/projects/ngx-oneforall-docs/src/app/categories/pipes/pages/truncate/index.md
@@ -2,6 +2,12 @@
 
 The `TruncatePipe` shortens strings to a specified length with optional word boundary and position support.
 
+### Installation
+
+```ts
+import { TruncatePipe } from 'ngx-oneforall/pipes/truncate';
+```
+
 ### Usage
 
 ```html file="./snippets.html"#L2-L2


### PR DESCRIPTION
This PR improves the documentation consistency across all pipe components by adding a dedicated Installation section that includes the TypeScript import statement. Previously, some docs were missing import examples entirely, while others had inconsistent formatting.

<img width="865" height="591" alt="image" src="https://github.com/user-attachments/assets/b2827a8d-0e88-47eb-88f6-5e7b3081b27e" />
